### PR TITLE
Add support for service account impersonation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Next
 
 * PR #69: Fixed dependency shading, reduced the distributable jar size
+* PR #76: Added support for service account impersonation
 
 ## 2.0.0-preview - 2023-04-12
 

--- a/README-template.md
+++ b/README-template.md
@@ -412,6 +412,55 @@ Please note there are a few caveats:
 * Reading from views is **disabled** by default. In order to enable it, set the `viewsEnabled` configuration
   property to `true`.
 
+## Authentication
+
+The connector needs an instance of a GoogleCredentials in order to connect to the BigQuery APIs.
+
+By default on Dataproc, the connector automatically uses the cluster service account's credentials.
+
+There are multiple options to override the default behavior and to provide custom credentials:
+
+* Set the path to a service account's JSON private key in the `GOOGLE_APPLICATION_CREDENTIALS`
+  environment variable.
+* Set the path to a service account's JSON private key in the `bq.credentials.file` configuration
+  property.
+* Set a base64-encoded service account JSON private key in the `bq.credentials.key` configuration
+  property.
+* Set the fully qualified class name of a custom [access token provider]((https://github.com/GoogleCloudDataproc/spark-bigquery-connector/tree/master/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/AccessTokenProvider.java))
+  implementation in the `bq.access.token.provider.fqcn` configuration property. The class must be
+  implemented in Java or other JVM languages such as Scala or Kotlin. It must either have a no-arg
+  constructor or a constructor accepting a single `java.util.String` parameter. This parameter can
+  be supplied using the `bq.access.token.provider.config` configuration property. If the property is
+  not set then the no-arg constructor will be called. The JAR containing the implementation class
+  should be on the cluster's classpath.
+* Define service account impersonation for specific users, specific groups, or for all
+  users by default using below properties:
+
+    - `bq.impersonation.service.account.for.user.<USER_NAME>` (not set by default)
+
+      The service account to be impersonated for a specific user. You can specify multiple
+      properties using that pattern for multiple users.
+
+    - `bq.impersonation.service.account.for.group.<GROUP_NAME>` (not set by default)
+
+      The service account to be impersonated for a specific group. You can specify multiple
+      properties using that pattern for multiple groups.
+
+    - `bq.impersonation.service.account` (not set by default)
+
+      Default service account to be impersonated for all users.
+
+  If any of the above properties are set then the service account specified will be impersonated by
+  generating a short-lived credentials when accessing BigQuery.
+
+  If more than one property is set then the service account associated with the username will take
+  precedence over the service account associated with the group name for a matching user and group,
+  which in turn will take precedence over default service account impersonation.
+
+* For simpler applications where access token refresh is not required, pass the access token itself
+  with the `bq.access.token` configuration property. You can generate an access token by running
+  `gcloud auth application-default print-access-token`.
+
 ## Known issues and limitations
 
 * The `UPDATE`, `MERGE`, and `DELETE`, and `ALTER TABLE` statements are currently not supported.

--- a/connector/src/test/java/com/google/cloud/hive/bigquery/connector/integration/ImpersonationTests.java
+++ b/connector/src/test/java/com/google/cloud/hive/bigquery/connector/integration/ImpersonationTests.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2023 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.hive.bigquery.connector.integration;
+
+import static com.google.cloud.hive.bigquery.connector.TestUtils.HIVE_ALL_TYPES_TABLE_DDL;
+import static com.google.cloud.hive.bigquery.connector.config.HiveBigQueryConfig.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.api.client.http.HttpResponseException;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.junit.jupiter.api.Test;
+import test.hivebqcon.com.google.gson.Gson;
+import test.hivebqcon.com.google.gson.JsonObject;
+import test.hivebqcon.com.google.gson.reflect.TypeToken;
+
+public class ImpersonationTests extends IntegrationTestsBase {
+
+  public static JsonObject getErrorJsonFromHttpResponseException(
+      Throwable e, String stackTraceClassName, String stackTraceMethodName) {
+    StackTraceElement[] stackTrace = e.getStackTrace();
+    for (StackTraceElement element : stackTrace) {
+      if (e instanceof HttpResponseException
+          && element.getClassName().equals(stackTraceClassName)
+          && element.getMethodName().equals(stackTraceMethodName)) {
+        HttpResponseException httpError = (HttpResponseException) e;
+        Gson gson = new Gson();
+        TypeToken<JsonObject> token = new TypeToken<JsonObject>() {};
+        return gson.fromJson(httpError.getContent(), token.getType());
+      }
+    }
+    if (e.getCause() != null) {
+      return getErrorJsonFromHttpResponseException(
+          e.getCause(), stackTraceClassName, stackTraceMethodName);
+    }
+    return null;
+  }
+
+  @Test
+  public void testGlobalImpersonation() {
+    String sa = "abc@example.iam.gserviceaccount.com";
+    hive.setHiveConfValue("bq.impersonation.service.account", sa);
+    initHive();
+    Throwable exception =
+        assertThrows(
+            RuntimeException.class, () -> createManagedTable("abcd", HIVE_ALL_TYPES_TABLE_DDL));
+    JsonObject error =
+        getErrorJsonFromHttpResponseException(
+            exception, "com.google.auth.oauth2.ImpersonatedCredentials", "refreshAccessToken");
+    assertEquals(
+        error.getAsJsonObject("error").get("message").getAsString(),
+        "Not found; Gaia id not found for email " + sa);
+  }
+
+  @Test
+  public void testImpersonationForUser() {
+    String user = "bob";
+    String sa = "bob@example.iam.gserviceaccount.com";
+    hive.setHiveConfValue("bq.impersonation.service.account.for.user." + user, sa);
+    initHive();
+    UserGroupInformation ugi = UserGroupInformation.createRemoteUser(user);
+    ugi.doAs(
+        (java.security.PrivilegedAction<Void>)
+            () -> {
+              Throwable exception =
+                  assertThrows(
+                      RuntimeException.class,
+                      () -> createManagedTable("abcd", HIVE_ALL_TYPES_TABLE_DDL));
+              JsonObject error =
+                  getErrorJsonFromHttpResponseException(
+                      exception,
+                      "com.google.auth.oauth2.ImpersonatedCredentials",
+                      "refreshAccessToken");
+              assertEquals(
+                  error.getAsJsonObject("error").get("message").getAsString(),
+                  "Not found; Gaia id not found for email " + sa);
+              return null;
+            });
+  }
+
+  @Test
+  public void testImpersonationForGroup() {
+    String user = "bob";
+    String[] groups = new String[] {"datascience"};
+    String sa = "datascience-team@example.iam.gserviceaccount.com";
+    hive.setHiveConfValue("bq.impersonation.service.account.for.group." + "datascience", sa);
+    initHive();
+    UserGroupInformation ugi = UserGroupInformation.createUserForTesting(user, groups);
+    ugi.doAs(
+        (java.security.PrivilegedAction<Void>)
+            () -> {
+              Throwable exception =
+                  assertThrows(
+                      RuntimeException.class,
+                      () -> createManagedTable("abcd", HIVE_ALL_TYPES_TABLE_DDL));
+              JsonObject error =
+                  getErrorJsonFromHttpResponseException(
+                      exception,
+                      "com.google.auth.oauth2.ImpersonatedCredentials",
+                      "refreshAccessToken");
+              assertEquals(
+                  error.getAsJsonObject("error").get("message").getAsString(),
+                  "Not found; Gaia id not found for email " + sa);
+              return null;
+            });
+  }
+}

--- a/hive-bigquery-parent/pom.xml
+++ b/hive-bigquery-parent/pom.xml
@@ -62,7 +62,7 @@
         <jackson.version>2.12.7.1</jackson.version>
         <protobuf.version>3.21.12</protobuf.version>
         <legacy-bigquery-connector.version>hadoop2-1.0.0</legacy-bigquery-connector.version>
-        <bigquery-connector-common.version>0.30.0</bigquery-connector-common.version>
+        <bigquery-connector-common.version>0.31.0</bigquery-connector-common.version>
         <google-cloud-dataproc.version>4.7.0</google-cloud-dataproc.version>
         <google-cloud-storage.version>2.20.1</google-cloud-storage.version>
         <grpc.version>1.53.0</grpc.version>


### PR DESCRIPTION
This PR depends on this other PR in the `bigquery-connector-common` library: https://github.com/GoogleCloudDataproc/spark-bigquery-connector/pull/950