### PR TITLE
Fix to delete temporary table when insert overwrite fail, not failing query when fail to delete temporary table/files

### DIFF
--- a/connector/src/main/java/com/google/cloud/hive/bigquery/connector/output/direct/DirectOutputCommitter.java
+++ b/connector/src/main/java/com/google/cloud/hive/bigquery/connector/output/direct/DirectOutputCommitter.java
@@ -90,7 +90,11 @@ public class DirectOutputCommitter {
             jobDetails.getFinalTableId(),
             bigQuerySchema,
             opts.getEnableModeCheckForSchemaFields());
-    writerContext.commit(streamNames);
+    try {
+      writerContext.commit(streamNames);
+    } finally {
+      writerContext.clean();
+    }
   }
 
   public static void abortJob(Configuration conf, JobDetails jobDetails) {
@@ -112,6 +116,6 @@ public class DirectOutputCommitter {
             jobDetails.getFinalTableId(),
             bigQuerySchema,
             config.getEnableModeCheckForSchemaFields());
-    writerContext.abort();
+    writerContext.clean();
   }
 }

--- a/connector/src/main/java/com/google/cloud/hive/bigquery/connector/output/direct/DirectWriterContext.java
+++ b/connector/src/main/java/com/google/cloud/hive/bigquery/connector/output/direct/DirectWriterContext.java
@@ -119,13 +119,16 @@ public class DirectWriterContext {
     // Special case for "INSERT OVERWRITE" statements: Overwrite the final
     // destination table with the contents of the temporary table.
     if (destinationTableId != null && !destinationTableId.equals(tableIdToWrite)) {
+      LOG.info("Loading into destination table {}", destinationTableId);
       Job overwriteJob =
           bigQueryClient.overwriteDestinationWithTemporary(tableIdToWrite, destinationTableId);
       BigQueryClient.waitForJob(overwriteJob);
-      Preconditions.checkState(
-          bigQueryClient.deleteTable(tableIdToWrite),
-          new BigQueryConnectorException(
-              String.format("Could not delete temporary table %s from BigQuery", tableIdToWrite)));
+      try {
+        LOG.info("Deleting temprory table {}", tableIdToWrite);
+        bigQueryClient.deleteTable(tableIdToWrite);
+      } catch (Exception e) {
+        LOG.warn("Error deleting temporary table ", e);
+      }
     }
   }
 

--- a/connector/src/main/java/com/google/cloud/hive/bigquery/connector/output/indirect/IndirectOutputCommitter.java
+++ b/connector/src/main/java/com/google/cloud/hive/bigquery/connector/output/indirect/IndirectOutputCommitter.java
@@ -69,8 +69,12 @@ public class IndirectOutputCommitter {
         bqClient.loadDataIntoTable(
             opts, avroFiles, formatOptions, writeDisposition, Optional.empty());
       } finally {
-        // Delete all the Avro files from GCS
-        JobUtils.deleteJobTempOutput(conf, jobDetails);
+        try {
+          // Delete all the Avro files from GCS
+          JobUtils.deleteJobTempOutput(conf, jobDetails);
+        } catch (Exception e) {
+          LOG.warn("Error deleting job temporary files", e);
+        }
       }
     }
   }

--- a/connector/src/main/java/com/google/cloud/hive/bigquery/connector/output/indirect/IndirectOutputCommitter.java
+++ b/connector/src/main/java/com/google/cloud/hive/bigquery/connector/output/indirect/IndirectOutputCommitter.java
@@ -64,18 +64,9 @@ public class IndirectOutputCommitter {
               ? WriteDisposition.WRITE_TRUNCATE
               : WriteDisposition.WRITE_APPEND;
       LOG.info("Loading avroFiles [ " + Joiner.on(",").join(avroFiles) + "]");
-      try {
-        // Load the Avro files into BigQuery
-        bqClient.loadDataIntoTable(
-            opts, avroFiles, formatOptions, writeDisposition, Optional.empty());
-      } finally {
-        try {
-          // Delete all the Avro files from GCS
-          JobUtils.deleteJobTempOutput(conf, jobDetails);
-        } catch (Exception e) {
-          LOG.warn("Error deleting job temporary files", e);
-        }
-      }
+      // Load the Avro files into BigQuery
+      bqClient.loadDataIntoTable(
+          opts, avroFiles, formatOptions, writeDisposition, Optional.empty());
     }
   }
 }

--- a/connector/src/main/java/com/google/cloud/hive/bigquery/connector/utils/FileSystemUtils.java
+++ b/connector/src/main/java/com/google/cloud/hive/bigquery/connector/utils/FileSystemUtils.java
@@ -54,10 +54,10 @@ public class FileSystemUtils {
   }
 
   /** Delete files in a path. */
-  public static void deleteFilesOnExit(Configuration conf, Path dir) throws IOException {
+  public static void deleteFiles(Configuration conf, Path dir) throws IOException {
     FileSystem fs = dir.getFileSystem(conf);
     if (fs.exists(dir)) {
-      fs.deleteOnExit(dir);
+      fs.delete(dir);
     }
   }
 

--- a/connector/src/test/java/com/google/cloud/hive/bigquery/connector/integration/WriteIntegrationTests.java
+++ b/connector/src/test/java/com/google/cloud/hive/bigquery/connector/integration/WriteIntegrationTests.java
@@ -79,16 +79,8 @@ public class WriteIntegrationTests extends IntegrationTestsBase {
     // Insert data using Hive
     insert(engine, HiveBigQueryConfig.WRITE_METHOD_INDIRECT, testGcsPath);
 
-    // Check that the blob was created by the job.
-    // Note: The blobs are still present here during the test execution because the
-    // Hive/Hadoop session is still on, but in production those files would be
-    // automatically be cleaned up at the end of the job.
     blobs = getBlobs(testBucketName, testGcsDir);
-    assertEquals(1, blobs.size(), "Actual blobs: " + blobs);
-    String blobName = blobs.get(0).getName();
-    assertTrue(
-        blobName.startsWith(testGcsDir) && blobName.endsWith(".avro"),
-        "Unexpected blob name: " + blobName);
+    assertEquals(0, blobs.size(), "Unexpected blobs: " + blobs);
   }
 
   // ---------------------------------------------------------------------------------------------------

--- a/connector/src/test/java/com/google/cloud/hive/bigquery/connector/integration/WriteIntegrationTests.java
+++ b/connector/src/test/java/com/google/cloud/hive/bigquery/connector/integration/WriteIntegrationTests.java
@@ -79,8 +79,14 @@ public class WriteIntegrationTests extends IntegrationTestsBase {
     // Insert data using Hive
     insert(engine, HiveBigQueryConfig.WRITE_METHOD_INDIRECT, testGcsPath);
 
+    // Query workdir not deleted yet, but there should be no temporary avro files
     blobs = getBlobs(testBucketName, testGcsDir);
-    assertEquals(0, blobs.size(), "Unexpected blobs: " + blobs);
+    for (int i = 0; i < blobs.size(); i++) {
+      String blobName = blobs.get(i).getName();
+      assertTrue(
+          blobName.startsWith(testGcsDir) && !blobName.endsWith(".avro"),
+          "Unexpected blob name: " + blobName);
+    }
   }
 
   // ---------------------------------------------------------------------------------------------------

--- a/connector/src/test/java/com/google/cloud/hive/bigquery/connector/utils/JobUtilsTest.java
+++ b/connector/src/test/java/com/google/cloud/hive/bigquery/connector/utils/JobUtilsTest.java
@@ -47,10 +47,10 @@ public class JobUtilsTest {
     Configuration conf = new Configuration();
     conf.set("hive.query.id", "query123");
     conf.set("hadoop.tmp.dir", "/tmp");
-    Path path = JobUtils.getWorkDir(conf);
+    Path path = JobUtils.getQueryWorkDir(conf);
     assertEquals("/tmp/bq-hive-query123", path.toString());
     conf.set("bq.work.dir.parent.path", "/my/workdir");
-    path = JobUtils.getWorkDir(conf);
+    path = JobUtils.getQueryWorkDir(conf);
     assertEquals("/my/workdir/bq-hive-query123", path.toString());
   }
 


### PR DESCRIPTION
Delete temporary table used by insert overwrite when insert overwrite fails
also fix the bug when deleting temporary table/files fail should not fail the insert query