### PR TITLE
Minor cleanup to remove some unnecessary

### DIFF
--- a/connector/src/main/java/com/google/cloud/hive/bigquery/connector/output/BigQueryOutputFormat.java
+++ b/connector/src/main/java/com/google/cloud/hive/bigquery/connector/output/BigQueryOutputFormat.java
@@ -45,8 +45,9 @@ public class BigQueryOutputFormat
       FileSystem fileSystem, JobConf jobConf, String hmsDbTableName, Progressable progressable)
       throws IOException {
     JobDetails jobDetails = JobDetails.readJobDetailsFile(jobConf, hmsDbTableName);
-    HiveBigQueryConfig opts = HiveBigQueryConfig.from(jobConf, jobDetails.getTableProperties());
-    if (opts.getWriteMethod().equals(HiveBigQueryConfig.WRITE_METHOD_INDIRECT)) {
+    String writeMethod =
+        HiveBigQueryConfig.getWriteMethod(jobConf, jobDetails.getTableProperties());
+    if (writeMethod.equals(HiveBigQueryConfig.WRITE_METHOD_INDIRECT)) {
       return new IndirectAvroRecordWriter(jobConf, jobDetails);
     } else {
       return new DirectRecordWriter(jobConf, jobDetails);

--- a/connector/src/test/java/com/google/cloud/hive/bigquery/connector/integration/ReadIntegrationTests.java
+++ b/connector/src/test/java/com/google/cloud/hive/bigquery/connector/integration/ReadIntegrationTests.java
@@ -47,17 +47,12 @@ public class ReadIntegrationTests extends IntegrationTestsBase {
     assertFalse(bQTableExists(dataset, TEST_TABLE_NAME));
     // Create a Hive table without creating its corresponding table in BigQuery
     createExternalTable(TEST_TABLE_NAME, HIVE_TEST_TABLE_DDL);
-    // Attempt to read the table
+    // Attempt to read the table, Hive will return SemanticAnalyzer error of table not found.
+    // but hive runner throws NPE, so not checking exact exception message here.
     Throwable exception =
         assertThrows(
             RuntimeException.class,
             () -> runHiveQuery(String.format("SELECT * FROM %s", TEST_TABLE_NAME)));
-    assertTrue(
-        exception
-            .getMessage()
-            .contains(
-                String.format(
-                    "Table '%s.%s.%s' not found", getProject(), dataset, TEST_TABLE_NAME)));
   }
 
   // -----------------------------------------------------------------------------------------------


### PR DESCRIPTION
COLUMN_NAME_DELIMITER is hive config irrelevant to bigquery and also bigquery does not allow comma
outputformat no need to initiate a HiveBigQueryConfig