### PR TITLE
Fix to handle pseudo columns while serializing

### DIFF
--- a/connector/src/main/java/com/google/cloud/hive/bigquery/connector/input/arrow/ArrowRecordReader.java
+++ b/connector/src/main/java/com/google/cloud/hive/bigquery/connector/input/arrow/ArrowRecordReader.java
@@ -57,7 +57,7 @@ public class ArrowRecordReader
     for (int i = 0; i < numColumnsInSchemaRoot; i++) {
       FieldVector fieldVector = schemaRoot.getVector(i);
       String fieldName = fieldVector.getName();
-      int colIndex = columnNames.indexOf(fieldName);
+      int colIndex = columnNames.indexOf(fieldName.toLowerCase()); // added toLowerCase method to match pseduo columns in hive schema
       if (colIndex == -1) {
         throw new RuntimeException(
             "Unable to find column " + fieldName + " in columns " + columnNames);

--- a/connector/src/main/java/com/google/cloud/hive/bigquery/connector/input/avro/AvroRecordReader.java
+++ b/connector/src/main/java/com/google/cloud/hive/bigquery/connector/input/avro/AvroRecordReader.java
@@ -68,7 +68,7 @@ public class AvroRecordReader implements RecordReader<NullWritable, ObjectWritab
     List<Schema.Field> fields = actualSchema.getFields();
     Object[] row = new Object[columnNames.size()];
     for (Schema.Field field : fields) {
-      int colIndex = columnNames.indexOf(field.name());
+      int colIndex = columnNames.indexOf(field.name().toLowerCase());  // added toLowerCase method to match pseduo columns in hive schema
       ObjectInspector fieldObjectInspector =
           rowObjectInspector.getStructFieldRef(field.name()).getFieldObjectInspector();
       row[colIndex] =


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudDataproc/hive-bigquery-connector/issues/96
The pseudo columns are handled such that they are in upper-case while querying BQ, while they are in lower-case in hive schema. Here, this was not properly handled as the serializeRow method has pseudo columns in upper-case, but required them to be in lowercase.