### PR TITLE
Accepntance test parameterization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ buildNumber.properties
 hive-exec*.jar
 tez-local-cache*
 tez-conf.pb
+sandbox-flavor
+/connector/.flattened-pom.xml

--- a/connector/src/test/java/com/google/cloud/hive/bigquery/connector/acceptance/AcceptanceTestConstants.java
+++ b/connector/src/test/java/com/google/cloud/hive/bigquery/connector/acceptance/AcceptanceTestConstants.java
@@ -20,7 +20,14 @@ import org.apache.parquet.Strings;
 
 public class AcceptanceTestConstants {
 
-  public static final String REGION = "us-west1";
+  public static final String REGION = Preconditions.checkNotNull(System.getenv("BIGLAKE_REGION"),
+          "Please set the 'BIGLAKE_REGION' environment variable");
+
+  public static final String SUBNET = Preconditions.checkNotNull(System.getenv("SUBNET"),
+          "Please set the 'SUBNET' environment variable");
+
+  public static final String SERVICE_ACCOUNT = Preconditions.checkNotNull(System.getenv("SERVICE_ACCOUNT"),
+          "Please set the 'SERVICE_ACCOUNT' environment variable");
   public static final String DATAPROC_ENDPOINT = REGION + "-dataproc.googleapis.com:443";
   public static final String PROJECT_ID =
       Preconditions.checkNotNull(

--- a/connector/src/test/java/com/google/cloud/hive/bigquery/connector/acceptance/DataprocAcceptanceTestBase.java
+++ b/connector/src/test/java/com/google/cloud/hive/bigquery/connector/acceptance/DataprocAcceptanceTestBase.java
@@ -25,6 +25,8 @@ import static com.google.cloud.hive.bigquery.connector.acceptance.AcceptanceTest
 import static com.google.cloud.hive.bigquery.connector.acceptance.AcceptanceTestConstants.DATAPROC_ENDPOINT;
 import static com.google.cloud.hive.bigquery.connector.acceptance.AcceptanceTestConstants.PROJECT_ID;
 import static com.google.cloud.hive.bigquery.connector.acceptance.AcceptanceTestConstants.REGION;
+import static com.google.cloud.hive.bigquery.connector.acceptance.AcceptanceTestConstants.SERVICE_ACCOUNT;
+import static com.google.cloud.hive.bigquery.connector.acceptance.AcceptanceTestConstants.SUBNET;
 import static com.google.cloud.hive.bigquery.connector.acceptance.AcceptanceTestUtils.createBqDataset;
 import static com.google.cloud.hive.bigquery.connector.acceptance.AcceptanceTestUtils.deleteBqDatasetAndTables;
 import static com.google.cloud.hive.bigquery.connector.acceptance.AcceptanceTestUtils.generateClusterName;
@@ -197,9 +199,10 @@ public class DataprocAcceptanceTestBase {
                         .setExecutableFile(String.format(connectorInitActionUri, REGION)))
                 .setGceClusterConfig(
                     GceClusterConfig.newBuilder()
-                        .setNetworkUri("default")
+                        .setSubnetworkUri(SUBNET)
                         .setZoneUri(REGION + "-a")
-                        .putMetadata("hive-bigquery-connector-url", connectorJarUri))
+                        .putMetadata("hive-bigquery-connector-url", connectorJarUri)
+                        .setServiceAccount(SERVICE_ACCOUNT))
                 .setMasterConfig(
                     InstanceGroupConfig.newBuilder()
                         .setNumInstances(1)


### PR DESCRIPTION
During acceptance test, there is a need to setup a dataproc cluster which is handled by the test setup - however, there are some issues setting this up, when using a clean created GCP project:
1. new projects doesn't necessarily have `default` VPC network. To avoid this, I added a SUBNET envrionment variable to allow user to choose the network to set this up in.
2. By default, the Dataproc cluster is trying to use the default compute service account, which doesn't have the permissions to setup everything. I added an environment variable to establish which service account should be used to setup the dataproc cluster.
3. I've changed the REGION constant of the acceptance tests base class to reuse the `BIGLAKE_REGION` environment variable as some users might have a project setup for this in a different region with subnets in different regions.

General cleanup:
Added a couple of entries to .gitignore of files that are auto-generated.