### PR TITLE
Simplify acceptance tests

### DIFF
--- a/README-template.md
+++ b/README-template.md
@@ -40,7 +40,11 @@ To build the connector jar:
 
 ### Prerequisite
 
-Make sure you have the BigQuery Storage API enabled in your GCP project. Follow [these instructions](https://cloud.google.com/bigquery/docs/reference/storage/#enabling_the_api).
+Enable the BigQuery Storage API for your project:
+
+```sh
+gcloud services enable bigquerystorage.googleapis.com
+```
 
 ### Option 1: connectors init action
 
@@ -614,19 +618,19 @@ There are multiple options to override the default behavior and to provide custo
   for specific users, specific groups, or for all users that run the Hive query by default using
   the below properties:
 
-    - `bq.impersonation.service.account.for.user.<USER_NAME>` (not set by default)
+  - `bq.impersonation.service.account.for.user.<USER_NAME>` (not set by default)
 
-      The service account to be impersonated for a specific user. You can specify multiple
-      properties using that pattern for multiple users.
+    The service account to be impersonated for a specific user. You can specify multiple
+    properties using that pattern for multiple users.
 
-    - `bq.impersonation.service.account.for.group.<GROUP_NAME>` (not set by default)
+  - `bq.impersonation.service.account.for.group.<GROUP_NAME>` (not set by default)
 
-      The service account to be impersonated for a specific group. You can specify multiple
-      properties using that pattern for multiple groups.
+    The service account to be impersonated for a specific group. You can specify multiple
+    properties using that pattern for multiple groups.
 
-    - `bq.impersonation.service.account` (not set by default)
+  - `bq.impersonation.service.account` (not set by default)
 
-      Default service account to be impersonated for all users.
+    Default service account to be impersonated for all users.
 
   If any of the above properties are set then the service account specified will be impersonated by
   generating a short-lived credentials when accessing BigQuery.
@@ -711,7 +715,7 @@ export PROJECT=my-gcp-project
 export BIGLAKE_LOCATION=us
 export BIGLAKE_REGION=us-central1
 export BIGLAKE_CONNECTION=hive-integration-tests
-export BIGLAKE_BUCKET=${USER}-biglake-test
+export BIGLAKE_BUCKET=${PROJECT}-biglake-tests
 ```
 
 Create the test BigLake connection:
@@ -773,19 +777,16 @@ You must use Java version 8, as it's the version that Hive itself uses. Make sur
 
 Acceptance tests create Dataproc clusters with the connector and run jobs to verify it.
 
-The following environment variables must be set and **exported** first.
-
-* `GOOGLE_APPLICATION_CREDENTIALS` - the full path to a credentials JSON, either a service account or the result of a
-  `gcloud auth login` run
-* `GOOGLE_CLOUD_PROJECT` - The Google cloud platform project used to test the connector
-* `TEST_BUCKET` - The GCS bucked used to test writing to BigQuery during the integration tests
-* `ACCEPTANCE_TEST_BUCKET` - The GCS bucked used to test writing to BigQuery during the acceptance tests
-
 To run the acceptance tests:
 
-```sh
-./mvnw verify -Pdataproc21,acceptance
-```
+1. Enable the Dataproc API for your project:
+   ```sh
+   gcloud services enable dataproc.googleapis.com
+   ```
+2. Run the tests:
+   ```sh
+   ./mvnw verify -Pdataproc21,acceptance
+   ```
 
 If you want to avoid rebuilding `shaded-dependencies` and `shaded-test-dependencies` when there is no changes in these
 modules, you can break it down into several steps, and only rerun the necessary steps:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ To build the connector jar:
 
 ### Prerequisite
 
-Make sure you have the BigQuery Storage API enabled in your GCP project. Follow [these instructions](https://cloud.google.com/bigquery/docs/reference/storage/#enabling_the_api).
+Enable the BigQuery Storage API for your project:
+
+```sh
+gcloud services enable bigquerystorage.googleapis.com
+```
 
 ### Option 1: connectors init action
 
@@ -614,19 +618,19 @@ There are multiple options to override the default behavior and to provide custo
   for specific users, specific groups, or for all users that run the Hive query by default using
   the below properties:
 
-    - `bq.impersonation.service.account.for.user.<USER_NAME>` (not set by default)
+  - `bq.impersonation.service.account.for.user.<USER_NAME>` (not set by default)
 
-      The service account to be impersonated for a specific user. You can specify multiple
-      properties using that pattern for multiple users.
+    The service account to be impersonated for a specific user. You can specify multiple
+    properties using that pattern for multiple users.
 
-    - `bq.impersonation.service.account.for.group.<GROUP_NAME>` (not set by default)
+  - `bq.impersonation.service.account.for.group.<GROUP_NAME>` (not set by default)
 
-      The service account to be impersonated for a specific group. You can specify multiple
-      properties using that pattern for multiple groups.
+    The service account to be impersonated for a specific group. You can specify multiple
+    properties using that pattern for multiple groups.
 
-    - `bq.impersonation.service.account` (not set by default)
+  - `bq.impersonation.service.account` (not set by default)
 
-      Default service account to be impersonated for all users.
+    Default service account to be impersonated for all users.
 
   If any of the above properties are set then the service account specified will be impersonated by
   generating a short-lived credentials when accessing BigQuery.
@@ -773,19 +777,16 @@ You must use Java version 8, as it's the version that Hive itself uses. Make sur
 
 Acceptance tests create Dataproc clusters with the connector and run jobs to verify it.
 
-The following environment variables must be set and **exported** first.
-
-* `GOOGLE_APPLICATION_CREDENTIALS` - the full path to a credentials JSON, either a service account or the result of a
-  `gcloud auth login` run
-* `GOOGLE_CLOUD_PROJECT` - The Google cloud platform project used to test the connector
-* `TEST_BUCKET` - The GCS bucked used to test writing to BigQuery during the integration tests
-* `ACCEPTANCE_TEST_BUCKET` - The GCS bucked used to test writing to BigQuery during the acceptance tests
-
 To run the acceptance tests:
 
-```sh
-./mvnw verify -Pdataproc21,acceptance
-```
+1. Enable the Dataproc API for your project:
+   ```sh
+   gcloud services enable dataproc.googleapis.com
+   ```
+2. Run the tests:
+   ```sh
+   ./mvnw verify -Pdataproc21,acceptance
+   ```
 
 If you want to avoid rebuilding `shaded-dependencies` and `shaded-test-dependencies` when there is no changes in these
 modules, you can break it down into several steps, and only rerun the necessary steps:

--- a/cloudbuild/presubmit.sh
+++ b/cloudbuild/presubmit.sh
@@ -27,7 +27,7 @@ readonly ACTION=$1
 readonly PROFILES="dataproc21"
 readonly MVN="./mvnw -B -e -Dmaven.repo.local=/workspace/.repository"
 
-export TEST_BUCKET=dataproc-integ-tests
+export INTEGRATION_BUCKET=dataproc-integ-tests
 export BIGLAKE_BUCKET=dataproc-integ-tests
 export BIGLAKE_CONNECTION=hive-integration-tests
 

--- a/connector/src/test/java/com/google/cloud/hive/bigquery/connector/acceptance/AcceptanceTestConstants.java
+++ b/connector/src/test/java/com/google/cloud/hive/bigquery/connector/acceptance/AcceptanceTestConstants.java
@@ -15,17 +15,13 @@
  */
 package com.google.cloud.hive.bigquery.connector.acceptance;
 
-import com.google.common.base.Preconditions;
 import org.apache.parquet.Strings;
 
 public class AcceptanceTestConstants {
 
   public static final String REGION = "us-west1";
   public static final String DATAPROC_ENDPOINT = REGION + "-dataproc.googleapis.com:443";
-  public static final String PROJECT_ID =
-      Preconditions.checkNotNull(
-          System.getenv("GOOGLE_CLOUD_PROJECT"),
-          "Please set the 'GOOGLE_CLOUD_PROJECT' environment variable");
+  public static final String ACCEPTANCE_BUCKET_ENV_VAR = "ACCEPTANCE_BUCKET";
 
   public static final boolean CLEAN_UP_CLUSTER =
       Strings.isNullOrEmpty(System.getenv("CLEAN_UP_CLUSTER"))

--- a/connector/src/test/java/com/google/cloud/hive/bigquery/connector/integration/IntegrationTestsBase.java
+++ b/connector/src/test/java/com/google/cloud/hive/bigquery/connector/integration/IntegrationTestsBase.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.cloud.bigquery.*;
 import com.google.cloud.hive.bigquery.connector.config.HiveBigQueryConfig;
-import com.google.cloud.storage.StorageException;
 import com.klarna.hiverunner.HiveRunnerExtension;
 import com.klarna.hiverunner.HiveShell;
 import com.klarna.hiverunner.annotations.HiveSQL;
@@ -68,16 +67,8 @@ public class IntegrationTestsBase {
 
   @BeforeAll
   public static void setUpAll() {
-    testBucketName = getTestBucket();
-
-    // Create the temp bucket for indirect writes if it does not exist.
-    try {
-      createBucket(testBucketName);
-    } catch (StorageException e) {
-      if (e.getCode() == 409) {
-        // The bucket already exists, which is okay.
-      }
-    }
+    testBucketName = getIntegrationTestBucket();
+    createBucket(testBucketName);
 
     // Upload datasets to the BigLake bucket.
     uploadBlob(


### PR DESCRIPTION
Use default values for some environment variables to make it easier to run the tests